### PR TITLE
Add zero arg constructor

### DIFF
--- a/provider/src/main/java/software/amazon/awssdk/services/kms/jce/provider/KmsProvider.java
+++ b/provider/src/main/java/software/amazon/awssdk/services/kms/jce/provider/KmsProvider.java
@@ -11,6 +11,9 @@ import java.util.stream.Stream;
 
 public class KmsProvider extends Provider {
 
+    public KmsProvider() {
+        this(KmsClient.builder().build());
+    }
     public KmsProvider(@NonNull KmsClient kmsClient) {
         super("KMS", "software.amazon.awssdk.services.kms.jce", "AWS KMS Provider");
         registerSignatures(kmsClient);


### PR DESCRIPTION
*Issue #, if available:*

KmsProvider cannot be installed via properties file or as command line argument to tools like jarsigner

*Description of changes:*

Add zero argument constructor that allows provider to be instantiated by jarsigner


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
